### PR TITLE
Set UI control to hidden (not set visibility to false) if the parent …

### DIFF
--- a/src/client_main/graphics/ui/base_control.cpp
+++ b/src/client_main/graphics/ui/base_control.cpp
@@ -20,7 +20,8 @@ namespace projectfarm::graphics::ui
     {
         for (const auto& child : this->_children)
         {
-            if (!child->GetIsVisible())
+            if (!child->GetIsVisible() ||
+                child->GetIsHidden())
             {
                 continue;
             }
@@ -305,6 +306,7 @@ namespace projectfarm::graphics::ui
     {
         if (!this->_canFocus ||
             !this->GetIsVisible() ||
+            this->GetIsHidden() ||
             !this->GetIsEnabled() ||
             !this->IsPointInControl(x, y))
         {
@@ -490,7 +492,7 @@ namespace projectfarm::graphics::ui
     {
         if (this->IsVisibleInParentControl())
         {
-            this->SetIsVisible(true);
+            this->SetIsHidden(false);
 
             if (!this->UpdateMaskToParentBoundary())
             {
@@ -500,7 +502,7 @@ namespace projectfarm::graphics::ui
         }
         else
         {
-            this->SetIsVisible(false);
+            this->SetIsHidden(true);
         }
 
         for (const auto& child : this->_children)

--- a/src/client_main/graphics/ui/base_control.h
+++ b/src/client_main/graphics/ui/base_control.h
@@ -97,6 +97,17 @@ namespace projectfarm::graphics::ui
             return this->_isVisible;
         }
 
+        void SetIsHidden(bool isHidden) noexcept
+        {
+            this->_isHidden = isHidden;
+        }
+
+        [[nodiscard]]
+        bool GetIsHidden() const noexcept
+        {
+            return this->_isHidden;
+        }
+
         void SetIsEnabled(bool isEnabled) noexcept
         {
             this->_isEnabled = isEnabled;
@@ -275,7 +286,18 @@ namespace projectfarm::graphics::ui
 
         std::string _id;
 
+        // Has this control explicitly been set to visible or not by
+        // a user or caller. A control may be not be visible even if the
+        // parent control is visible and this control is in the renderable
+        // portion of the screen
         bool _isVisible {true};
+
+        // Has this control been hidden by the system. The parent control
+        // may not be visible, but this control may still be set to visible.
+        // If so, this control should not be rendered.
+        bool _isHidden {false};
+
+        // Should this control respond to interactions and UI events or not.
         bool _isEnabled {true};
 
         // can this control be focus?


### PR DESCRIPTION
…control is not visible.

Fix #14.